### PR TITLE
fix/global exception handler

### DIFF
--- a/backend/src/main/java/com/mynt/mynt/util/dto/ResultResponseDTO.java
+++ b/backend/src/main/java/com/mynt/mynt/util/dto/ResultResponseDTO.java
@@ -1,22 +1,21 @@
 package com.mynt.mynt.util.dto;
 
-import com.mynt.mynt.util.exceptions.MyntExceptions;
+import com.mynt.mynt.util.exceptions.ErrorResponse;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.Setter;
 
 import javax.xml.transform.Result;
 
 @Getter
+@Setter
+@AllArgsConstructor
 public class ResultResponseDTO<T> {
 
   private static final String SUCCESS = "SUCCESS";
   private static final String ERROR = "ERROR";
-  private final T object;
-  private String result;
-
-  public ResultResponseDTO(String result, T object) {
-    this.result = result;
-    this.object = object;
-  }
+  private String message;
+  private final T result;
 
   public static <T> ResultResponseDTO<T> success() {
     return new ResultResponseDTO<>(SUCCESS, null);
@@ -26,7 +25,7 @@ public class ResultResponseDTO<T> {
     return new ResultResponseDTO<>(SUCCESS, object);
   }
 
-  public static <T> ResultResponseDTO<T> error(T exception) {
-    return new ResultResponseDTO<>(ERROR, exception);
+  public static <T> ResultResponseDTO<T> error(T errorResponse) {
+    return new ResultResponseDTO<>(ERROR, errorResponse);
   }
 }

--- a/backend/src/main/java/com/mynt/mynt/util/exceptions/ErrorResponse.java
+++ b/backend/src/main/java/com/mynt/mynt/util/exceptions/ErrorResponse.java
@@ -1,0 +1,27 @@
+package com.mynt.mynt.util.exceptions;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+
+  private HttpStatusCode code;
+
+  private String message;
+
+  public static ErrorResponse of(HttpStatusCode code, String message) {
+    return new ErrorResponse(code, message);
+  }
+
+  public static ErrorResponse of(ErrorCode errorCode) {
+    return new ErrorResponse(errorCode.getStatus(), errorCode.getDescription());
+  }
+
+  public static ErrorResponse of(Exception e) {
+    return new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+  }
+}

--- a/backend/src/main/java/com/mynt/mynt/util/exceptions/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/mynt/mynt/util/exceptions/GlobalExceptionHandler.java
@@ -15,13 +15,13 @@ public class GlobalExceptionHandler {
   public ResponseEntity<?> handleException(MyntExceptions e) {
     return ResponseEntity
         .status(e.getErrorCode().getStatus())
-        .body(ResultResponseDTO.error(e));
+        .body(ResultResponseDTO.error(ErrorResponse.of(e)));
   }
 
   @ExceptionHandler(Exception.class)
   public ResponseEntity<?> handleException(Exception e) {
     return ResponseEntity
         .status(HttpStatus.INTERNAL_SERVER_ERROR)
-        .body(ResultResponseDTO.error(e));
+        .body(ResultResponseDTO.error(ErrorResponse.of(e)));
   }
 }


### PR DESCRIPTION
- Fixed Exception Handler for its HTTP conversion exception:
  - Exception Class is not Serializable and hence could be be rendered as a Http Response.
  - To fix this made extra Error Response class and rendered this class instead. 