### PR TITLE
Refactor/frontend remittances 1

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -25,6 +25,8 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation:3.3.0'
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/backend/src/main/java/com/mynt/mynt/controller/UserController.java
+++ b/backend/src/main/java/com/mynt/mynt/controller/UserController.java
@@ -1,0 +1,27 @@
+package com.mynt.mynt.controller;
+
+import com.mynt.mynt.dto.UserSignupRequest;
+import com.mynt.mynt.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class UserController {
+
+  private final UserService userService;
+
+  @PostMapping
+  public ResponseEntity<?> signup(@Valid @RequestBody UserSignupRequest request) {
+    return ResponseEntity
+        .status(HttpStatus.CREATED)
+        .body(userService.signup(request));
+  }
+}

--- a/backend/src/main/java/com/mynt/mynt/dto/UserSignupRequest.java
+++ b/backend/src/main/java/com/mynt/mynt/dto/UserSignupRequest.java
@@ -1,0 +1,22 @@
+package com.mynt.mynt.dto;
+
+
+import jakarta.validation.constraints.*;
+import lombok.*;
+
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserSignupRequest {
+
+  @Email
+  @NotBlank(message = "Email is Mandatory!")
+  private String email;
+
+  @Size(min = 8, max = 24, message = "Password has to be within 8 ~ 24 length")
+  @NotBlank(message = "Password is Mandatory!")
+  private String password;
+}

--- a/backend/src/main/java/com/mynt/mynt/service/UserService.java
+++ b/backend/src/main/java/com/mynt/mynt/service/UserService.java
@@ -1,0 +1,13 @@
+package com.mynt.mynt.service;
+
+
+import com.mynt.mynt.dto.UserSignupRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+
+  public String signup(UserSignupRequest request) {
+    return null;
+  }
+}

--- a/frontend/src/assets/styles/index.css
+++ b/frontend/src/assets/styles/index.css
@@ -1,0 +1,35 @@
+.remittance-page {
+    max-width: 600px;
+    margin: 20px auto;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+}
+
+.remittance-page form {
+    display: flex;
+    flex-direction: column;
+}
+
+footer {
+    text-align: center;
+    margin-top: auto;
+    padding: 1rem;
+}
+
+h1 {
+    font-weight: bold;
+}
+
+.App-header {
+    font-size: 24px;
+    margin-top: 10px;
+    margin-left: 10px;
+}
+
+.Remittance-page-header {
+    font-size: 20px;
+    margin-top: 10px;
+    margin-bottom: 10px;
+    text-align: center;
+}

--- a/frontend/src/components/CustomButton.js
+++ b/frontend/src/components/CustomButton.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Button } from '@chakra-ui/react';
+
+
+function CustomButton({
+  children,
+  size,
+  colour,
+  variant,
+  ...props
+}) {
+
+  const sizeList = {
+    large: 'lg',
+    medium: 'md',
+    small: 'sm',
+    xsmall: 'xs',
+  }
+
+  const colourList = {
+    gray: 'gray',
+    red: 'red',
+    orange: 'orange',
+    yellow: 'yellow',
+    green: 'green',
+    teal: 'teal',
+    blue: 'blue',
+    cyan: 'cyan',
+    purple: 'purple',
+    pink: 'pink',
+  }
+
+  return (
+    <Button 
+      colorScheme={colourList[colour] || 'teal'}
+      size={sizeList[size] || 'md'}
+      {...props} >{
+      children}
+    </Button>
+  );
+}
+
+
+export default CustomButton;

--- a/frontend/src/components/CustomInput.js
+++ b/frontend/src/components/CustomInput.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Input } from '@chakra-ui/react';
+
+function CustomInput({
+  children,
+
+  ...props
+}) {
+  return (
+    <Input 
+      
+      { ...props }
+      >
+      {children}
+    </Input>
+  );
+}
+
+export default CustomInput;

--- a/frontend/src/components/CustomLabel.js
+++ b/frontend/src/components/CustomLabel.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { FormLabel } from "@chakra-ui/react";
+
+
+function CustomLabel({
+  children
+}) {
+  
+  return (
+    <FormLabel>
+      {children}
+    </FormLabel>
+  )
+}
+
+export default CustomLabel;

--- a/frontend/src/pages/RemittancePage.js
+++ b/frontend/src/pages/RemittancePage.js
@@ -1,0 +1,61 @@
+import React, {useState} from 'react';
+import {Box, Input, FormLabel, FormControl, FormHelperText, Button } from '@chakra-ui/react';
+
+const Remittance = () => {
+    // State for form fields
+    const [senderName, setSenderName] = useState('');
+    const [recipientName, setRecipientName] = useState('');
+    const [amount, setAmount] = useState('');
+    const [paymentDate, setPaymentDate] = useState('');
+
+    const availableBalance = 1000; // To be replaced with logic to fetch balance dynamically from an API
+
+    // Function to handle form submission
+    const handleFormSubmit = (event) => {
+        event.preventDefault();
+        // To be added with logic to send the remittance data to a server or perform some other action based on the form inputs
+        console.log('Form submitted:', senderName, recipientName, amount);
+        // Reset form fields after submission
+        setSenderName('');
+        setRecipientName('');
+        setAmount('');
+    };
+
+    const remitanceInputList = [
+        { label: "From:", placeholder: "Payer's name", type:"text", required: true, value: senderName, onChange: () => setSenderName(e.target.value) },
+        { label: "To:", placeholder: "Payee's name", type:"text", required: true, value: recipientName, onChange: () => setRecipientName(e.target.value) },
+        { label: "Amount:", placeholder: 0, type:"number", required: true, value: amount, onChange: () => setRecipientName(e.target.value), helperText: `Available balance: ${availableBalance.toFixed(2)} KES` },
+    ];
+
+    const renderedRemittancesInput = remitanceInputList.map((inputList) => {
+        return (
+            <div key={inputList.label}>
+                <FormControl isRequired={inputList.required} margin='0.5em'>
+                    <FormLabel>{inputList.label}</FormLabel>
+                    <Input 
+                        margin='0.5em'
+                        placeholder={inputList.placeholder} 
+                        type={inputList.type}
+                        value={inputList.value}
+                        onChange={inputList.onChange}
+                        required={inputList.required}
+                    />
+                    {inputList.helperText ? <FormHelperText>{inputList.helperText}</FormHelperText> : null}
+                </FormControl>
+            </div>
+        );
+    });
+
+
+    return (
+        <Box className="remittance-page">
+            <h1 className="Remittance-page-header">Transfer</h1>
+            <form onSubmit={handleFormSubmit}>
+                {renderedRemittancesInput}
+                <Button margin='0.5em' type="submit">Send Money</Button>
+            </form>
+        </Box>
+    );
+};
+
+export default Remittance;


### PR DESCRIPTION
- created assets, pages, components folder
- created custom button, input, label components
- created remittances page
- changed hardcoded rendering into more dynamic renderings in which its content can always change
    
<img width="1322" alt="스크린샷 2024-06-20 오후 11 30 16" src="https://github.com/uob-group-10-mynt/mynt-finance-banking-app/assets/104866923/b147e780-c9e3-4386-83b0-9d6393fd985d">
    
For custom components, it is basically the identical components from chakra ui, however thought we could discuss refactoring these custom components to have more default settings such as mobile, or web buttons with its default stylings? For everyone's convenience? 