### PR TITLE
fix/frontend container row

### DIFF
--- a/frontend/src/components/DateTimeDisplay.js
+++ b/frontend/src/components/DateTimeDisplay.js
@@ -1,0 +1,15 @@
+import { Box } from "@chakra-ui/react";
+
+import CustomText from "./CustomText";
+
+
+function DateTimeDisplay({ time }) {
+  return (
+    <Box display='flex' flexDirection='column-reverse'>
+      <CustomText gray xsmall>{time.split('T')[0]}</CustomText>
+      <CustomText gray small>{time.split('T')[1].split('+')[0]}</CustomText>
+    </Box>
+  ); 
+}
+
+export default DateTimeDisplay;

--- a/frontend/src/components/InfoBlock.js
+++ b/frontend/src/components/InfoBlock.js
@@ -4,9 +4,13 @@ function InfoBlock({ children }) {
   const [ title , content ] = children;
 
   return (
-    <Box width='45%'>
-      <Box>{title}</Box>
-      <Box>{content}</Box>
+    <Box
+      display='flex'
+      flexDirection='column'
+      justifyContent='flex-start' 
+      width='45%'
+    >
+      {children}
     </Box>
   );
 }

--- a/frontend/src/pages/AccountPage.js
+++ b/frontend/src/pages/AccountPage.js
@@ -8,6 +8,7 @@ import CustomText from '../components/CustomText';
 import CustomButton from '../components/forms/CustomButton';
 import ContainerRowBalanceWrapper from '../components/ContainerRowBalanceWrapper';
 import InfoBlock from '../components/InfoBlock';
+import DateTimeDisplay from '../components/DateTimeDisplay';
 import CustomBox from '../components/CustomBox';
 
 
@@ -28,7 +29,7 @@ const fetchTransactionData = [
       'amount': '100',
       'currency': '$',
       'flow': '+',
-      'created_at': '2022-09-01',
+      'created_at': "2024-06-25T14:13:18+00:00",
   },
   {
       'id': '2',
@@ -36,7 +37,7 @@ const fetchTransactionData = [
       'amount': '10000.0',
       'currency': '₩',
       'flow': '-',
-      'created_at': '2022-09-01',
+      'created_at': "2024-06-25T14:13:18+00:00",
   },
 ];
 
@@ -55,8 +56,8 @@ function AccountPage() {
                 <>
                     <Icon name={data.payee_bank} />
                     <InfoBlock>
-                        <CustomText gray small>{data.payee_bank}</CustomText>
-                        <CustomText gray small>{data.created_at}</CustomText>
+                        <CustomText black small>{data.payee_bank}</CustomText>
+                        <DateTimeDisplay time={data.created_at}/>
                     </InfoBlock>
                     <ContainerRowBalanceWrapper>
                       <CustomText black big>{data.flow}{accountDetail.currencySymbol}{parseFloat(data.amount).toFixed(2)}</CustomText>

--- a/frontend/src/pages/DashboardPage.js
+++ b/frontend/src/pages/DashboardPage.js
@@ -7,6 +7,7 @@ import Container from '../components/Container';
 import Icon from '../components/Icon';
 import CustomText from '../components/CustomText';
 import InfoBlock from '../components/InfoBlock';
+import DateTimeDisplay from '../components/DateTimeDisplay';
 import ContainerRowBalanceWrapper from '../components/ContainerRowBalanceWrapper';
 import CustomBox from '../components/CustomBox';
 import Calendar from '../components/calendar/Calendar';
@@ -161,8 +162,8 @@ function DashboardPage() {
                 <>
                     <Icon name={data.payee_bank} />
                     <InfoBlock>
-                        <CustomText gray small>{data.payee_bank}</CustomText>
-                        <CustomText gray small>{data.created_at}</CustomText>
+                        <CustomText black small>{data.payee_bank}</CustomText>
+                        <DateTimeDisplay time={data.created_at}/>
                     </InfoBlock>
                     <ContainerRowBalanceWrapper>
                       <CustomText black big>


### PR DESCRIPTION
fixed time display reflecting currency cloud styled datetime

before the change on mobile screens the indentation looked inconsistent because the date format from currency cloud was too long `2024-07-01T14:13:18+00:00` 

so added DateTimeDisplay Component 

<img width="1339" alt="스크린샷 2024-07-18 오후 5 05 08" src="https://github.com/user-attachments/assets/ad0a19f2-e66c-4181-8ae2-ea3b041a4a8c">
