### PR TITLE
Feature/backend currencycloud update contact

### DIFF
--- a/backend/src/main/java/com/mynt/banking/currency_cloud/manage/contacts/ContactController.java
+++ b/backend/src/main/java/com/mynt/banking/currency_cloud/manage/contacts/ContactController.java
@@ -1,14 +1,11 @@
 package com.mynt.banking.currency_cloud.manage.contacts;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.mynt.banking.currency_cloud.manage.contacts.requestsDtos.CreateContact;
-import com.mynt.banking.currency_cloud.manage.contacts.requestsDtos.FindContact;
+import com.mynt.banking.currency_cloud.manage.contacts.requestsDtos.*;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
 
 @RestController
@@ -28,5 +25,15 @@ public class ContactController {
         return contactsService.findContact(requestBody);
     }
 
-
+    @PostMapping("/update/{id}")
+    public Mono<ResponseEntity<JsonNode>> updateContact(
+            @Schema(description = "Contact UUID")
+            @PathVariable(name = "id") String id,
+            @RequestBody UpdateContactRequest request
+    ) {
+        return contactsService.updateContact(
+                id,
+                request
+        );
+    }
 }

--- a/backend/src/main/java/com/mynt/banking/currency_cloud/manage/contacts/ContactsService.java
+++ b/backend/src/main/java/com/mynt/banking/currency_cloud/manage/contacts/ContactsService.java
@@ -1,16 +1,18 @@
 package com.mynt.banking.currency_cloud.manage.contacts;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mynt.banking.currency_cloud.manage.authenticate.AuthenticationService;
-import com.mynt.banking.currency_cloud.manage.accounts.requests.CreateAccountRequest;
-import com.mynt.banking.currency_cloud.manage.contacts.requestsDtos.CreateContact;
-import com.mynt.banking.currency_cloud.manage.contacts.requestsDtos.FindContact;
+import com.mynt.banking.currency_cloud.manage.contacts.requestsDtos.*;
+import com.mynt.banking.util.HashMapToQuiryPrams;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.annotations.processing.Find;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
+
+import java.util.HashMap;
 
 @Service
 @RequiredArgsConstructor
@@ -51,7 +53,25 @@ public class ContactsService {
                     }
                     return Mono.just(response);
                 });
+
     }
 
+    public Mono<ResponseEntity<JsonNode>> updateContact(
+            String id,
+            UpdateContactRequest request
+    ) {
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        HashMap<String, Object> prams = objectMapper.convertValue(request, HashMap.class);
+        String url = "/v2/contacts/" + id + "" + HashMapToQuiryPrams.hashMapToString(prams);
+        return webClient
+                .post()
+                .uri(url)
+                .header("X-Auth-Token", authenticationService.getAuthToken())
+                .bodyValue(request)
+                .exchangeToMono(response -> response.toEntity(JsonNode.class))
+                .flatMap(Mono::just);
+    }
 
 }

--- a/backend/src/main/java/com/mynt/banking/currency_cloud/manage/contacts/requestsDtos/UpdateContactRequest.java
+++ b/backend/src/main/java/com/mynt/banking/currency_cloud/manage/contacts/requestsDtos/UpdateContactRequest.java
@@ -1,0 +1,108 @@
+
+package com.mynt.banking.currency_cloud.manage.contacts.requestsDtos;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.Date;
+
+@Data
+@Builder
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@Schema(description = "Updates an existing contact. Returns the updated contact entity on success.")
+public class UpdateContactRequest {
+    
+    //@NotNull
+    @JsonProperty("first_name")
+    @Size(max = 255)
+    @Schema(description = "The contact's first name.",
+            example = " ")
+    @Builder.Default
+    private String firstname = "";
+    
+    //@NotNull
+    @JsonProperty("last_name")
+    @Size(max = 255)
+    @Schema(description = "The contact's last name.",
+            example = " ")
+    @Builder.Default
+    private String lastname = "";
+    
+    //@NotNull
+    @JsonProperty("email_address")
+    @Size(max = 255)
+    @Schema(description = "The contact's email address. A request to update a contact's email address does not immediately update the value. Instead, an email change request flow is initiated, sending notifications to both the old and new email addresses. The value will be updated when the change is confirmed via a link sent to the new email address.",
+            example = " ")
+    @Builder.Default
+    private String emailAddress = "";
+    
+    //@NotNull
+    @JsonProperty("your_reference")
+    @Size(max = 255)
+    @Schema(description = "User-generated reference code.",
+            example = " ")
+    @Builder.Default
+    private String yourReference = "";
+    
+    //@NotNull
+    @JsonProperty("phone_number")
+    @Size(max = 255)
+    @Schema(description = "The contact's phone number.",
+            example = " ")
+    @Builder.Default
+    private String phoneNumber = "";
+    
+    //@NotNull
+    @JsonProperty("mobile_phone_number")
+    @Size(max = 255)
+    @Schema(description = "The contact's mobile phone number.",
+            example = " ")
+    @Builder.Default
+    private String mobilePhoneNumber = "";
+    
+    //@NotNull
+    @JsonProperty("login_id")
+    @Size(max = 255)
+    @Schema(description = "The contact's Currencycloud login ID.",
+            example = " ")
+    @Builder.Default
+    private String loginId = "";
+    
+    //@NotNull
+    @JsonProperty("status")
+    @Size(max = 255)
+    @Schema(description = "Contact status - \"enabled\" allows the contact to conduct activity on the sub-account, \"not_enabled\" disables the contact.",
+            example = " ")
+    @Builder.Default
+    private String status = "";
+    
+    //@NotNull
+    @JsonProperty("locale")
+    @Size(max = 255)
+    @Schema(description = "Locale code (\"en\", \"en-US\", \"fr-FR\").",
+            example = " ")
+    @Builder.Default
+    private String locale = "";
+    
+    //@NotNull
+    @JsonProperty("timezone")
+    @Size(max = 255)
+    @Schema(description = "Timezone (\"Europe/London\", \"America/New_York\").",
+            example = " ")
+    @Builder.Default
+    private String timezone = "";
+    
+    //@NotNull
+    @JsonProperty("date_of_birth")
+    @Size(max = 255)
+    @Schema(description = "Contact's date of birth. ISO 8601 format YYYY-MM-DD. Required if account type is individual.",
+            example = " ")
+    @Builder.Default
+    private String dateOfBirth = "";
+    
+}

--- a/backend/src/test/java/services/cloudCurrencyTests/ContactCCTest.java
+++ b/backend/src/test/java/services/cloudCurrencyTests/ContactCCTest.java
@@ -6,6 +6,7 @@ import com.mynt.banking.currency_cloud.manage.accounts.requests.CreateAccountReq
 import com.mynt.banking.currency_cloud.manage.accounts.requests.FindAccountRequest;
 import com.mynt.banking.currency_cloud.manage.contacts.ContactsService;
 import com.mynt.banking.currency_cloud.manage.contacts.requestsDtos.CreateContact;
+import com.mynt.banking.currency_cloud.manage.contacts.requestsDtos.UpdateContactRequest;
 import com.mynt.banking.main;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -77,4 +78,29 @@ public class ContactCCTest {
 
     }
 
+    @Test
+    public void testUpdateContact() {
+        String ContactUUID = "0b297cfc-2116-4c52-9150-680ecf55f9d5";
+        UpdateContactRequest contact = UpdateContactRequest.builder()
+                .firstname("James")
+                .lastname("Love")
+                //.emailAddress("james.love@gmail.com")
+                // A request to update a contact's email address does not immediately update the value. Instead, an email change request flow is initiated
+
+                .phoneNumber("+44 7824792135")
+                .dateOfBirth("1997-08-13")
+                .build();
+
+        ResponseEntity<JsonNode> result = contactsService.updateContact(ContactUUID, contact).block();
+
+        assert result != null;
+        assertEquals(result.getStatusCode().value(), 200);
+
+        assertEquals(result.getBody().get("first_name").asText(), contact.getFirstname());
+        assertEquals(result.getBody().get("last_name").asText(), contact.getLastname());
+        //assertEquals(result.getBody().get("email_address").asText(), contact.getEmailAddress());
+        assertEquals(result.getBody().get("phone_number").asText(), contact.getPhoneNumber());
+        assertEquals(result.getBody().get("date_of_birth").asText(), contact.getDateOfBirth().toString());
+
+    }
 }


### PR DESCRIPTION
Please note, from the currency cloud api page: [update-contact](https://developer.currencycloud.com/api-reference/#update-contact)
> A request to update a contact's email address does not immediately update the value. Instead, an email change request flow is initiated, sending notifications to both the old and new email addresses. The value will be updated when the change is confirmed via a link sent to the new email address.

Therefore it needs alternative methods to test the change of email address, other than writing the java script for it.