### PR TITLE
[fix]: enable http in capacitor config

### DIFF
--- a/frontend/capacitor.config.ts
+++ b/frontend/capacitor.config.ts
@@ -3,7 +3,12 @@ import type { CapacitorConfig } from '@capacitor/cli';
 const config: CapacitorConfig = {
   appId: 'com.example.app',
   appName: 'testReact',
-  webDir: './webApp'
+  webDir: './webApp',
+  plugins: {
+    CapacitorHttp: {
+      enabled: true,
+    },
+  }
 };
 
 export default config;


### PR DESCRIPTION
Please note that in order for the android app to work, it is also needed to add the following to the application section of the AndroidManifest.xml file in the android/app/src/main folder:

        android:usesCleartextTraffic="true">